### PR TITLE
Add Marimo visualisation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiohappyeyeballs==2.3.4
 aiohttp==3.10.1
 aioitertools==0.11.0
 aiosignal==1.3.1
+altair==5.5.0
 anyio==4.4.0
 argon2-cffi==23.1.0
 argon2-cffi-bindings==21.2.0
@@ -128,7 +129,7 @@ pillow==10.4.0
 pip==24.0
 platformdirs==4.2.2
 plotly==5.23.0
-polars==0.19.19
+polars==1.16.0
 pooch==1.7.0
 prometheus-client==0.20.0
 prompt-toolkit==3.0.47

--- a/workspace/analysis/2024_11_30_csv_to_parquet.py
+++ b/workspace/analysis/2024_11_30_csv_to_parquet.py
@@ -1,0 +1,18 @@
+"""
+Convert csv to parquet for ease of plotting.
+Note on naming: always replace special signs (.=-) before saving files.
+"""
+from pathlib import Path
+import polars as pl
+
+
+dir_path = Path("/home/hhakem/projects/counterfactuals_projects/workspace/analysis/image_active_crop_dataset")
+fname = "embedding_VGG_image_crop_active_groups_fold_1epoch=77-train_acc=0.86-val_acc=0.77.csv"
+shared_working_dir = Path("/datastore/shared/attribution/data/")
+data = pl.read_csv(dir_path / fname)
+
+
+metadata = pl.read_csv(dir_path / "metadata.csv")
+new_data = pl.concat((metadata, data.select(pl.col("^column_[123]$")).rename(lambda x: f"PC{x[-1]}")), how="horizontal")
+new_data.write_parquet(shared_working_dir /  "main_data.parquet")
+

--- a/workspace/analysis/2024_11_30_marimo_explorer.py
+++ b/workspace/analysis/2024_11_30_marimo_explorer.py
@@ -1,0 +1,178 @@
+# 1. Visualise image
+# 2. Convert to functional argument
+# 3. Reproduce marimo example
+
+import marimo
+
+__generated_with = "0.9.27"
+app = marimo.App(width="full")
+
+
+@app.cell
+def __():
+    from pathlib import Path
+
+    import numpy
+    import polars as pl
+
+
+    df = pl.read_parquet("/datastore/shared/attribution/data/main_data.parquet")
+    return Path, df, numpy, pl
+
+
+@app.cell
+def __(Path):
+    from functools import cache
+
+    import zarr
+
+    @cache
+    def load_image(image_id: int, channel: int):
+        zarr_path = Path("/home/hhakem/projects/counterfactuals_projects/workspace/analysis/image_active_crop_dataset/imgs_labels_groups.zarr")
+        with zarr.open(zarr_path) as imgs:
+            return imgs["imgs"][image_id, channel]
+    return cache, load_image, zarr
+
+
+@app.cell
+def __(alt):
+    def scatter(df):
+        return (
+            alt.Chart(df)
+            .mark_circle()
+            .encode(
+                x=alt.X("PC1:Q"),#.scale(domain=(-2.5, 2.5)),
+                y=alt.Y("PC2:Q"),#.scale(domain=(-2.5, 2.5)),
+                color=alt.Color("Metadata_Batch:N"),
+                # shape=alt.Shape("Compound:N")
+            )
+            .properties(width=500, height=500)
+        )
+    return (scatter,)
+
+
+@app.cell
+def __(df, mo, scatter):
+    chart = mo.ui.altair_chart(scatter(df.to_pandas()))
+    chart
+    return (chart,)
+
+
+@app.cell
+def __(mo):
+    import string
+
+    channel = mo.ui.slider(0, 5, value=3, step=1, label="Channel")
+    clip_outliers = mo.ui.checkbox(value=False, label="Clip outliers")
+    return channel, clip_outliers, string
+
+
+@app.cell
+def __(chart, mo):
+    table = mo.ui.table(chart.value)
+    return (table,)
+
+
+@app.cell
+def __(channel, chart, clip_outliers, load_image, mo, table):
+    import math
+
+    import matplotlib.pyplot as plt
+    mo.stop(not len(chart.value))
+
+    import numpy as np
+
+    def clip_outliers_(image: np.ndarray, lower_percentile=1, upper_percentile=99):
+        """
+        Clips pixel values in a numpy image array to the specified percentile range.
+
+        Parameters:
+            image (np.ndarray): Input image array.
+            lower_percentile (float): Lower bound percentile for clipping (default 2.5 for 95% range).
+            upper_percentile (float): Upper bound percentile for clipping (default 97.5 for 95% range).
+
+        Returns:
+            np.ndarray: Image with values clipped to the specified percentile range.
+        """
+        # Calculate the percentile thresholds
+        lower_bound = np.percentile(image, lower_percentile)
+        upper_bound = np.percentile(image, upper_percentile)
+
+        # Clip the image values to the computed thresholds
+        clipped_image = np.clip(image, lower_bound, upper_bound)
+
+        return clipped_image
+
+    def show_images(indices, max_images=8):
+
+        indices = indices[:max_images]
+
+        images = [load_image(x, channel.value) for x in indices]
+
+        fig, axes = plt.subplots(min(2, len(indices)), math.ceil(len(indices)/2))
+        fig.set_size_inches(20, 5)
+        if len(indices) > 1:
+            for im, ax in zip(images, axes.T.flat):
+                if clip_outliers.value:
+                    im = clip_outliers_(im)
+
+                ax.imshow(im, cmap="gray")
+                ax.set_yticks([])
+                ax.set_xticks([])
+        else:
+            axes.imshow(images[0], cmap="gray")
+            axes.set_yticks([])
+            axes.set_xticks([])
+
+        plt.tight_layout()
+        return fig
+
+    selected_images = (
+        show_images(list(chart.value["site"]))
+        if not len(table.value)
+        else show_images(list(table.value["site"]))
+    )
+
+    mo.md(
+        f"""
+        **Here's a preview of the images you've selected**:
+
+        {channel}
+        {clip_outliers}
+
+        {mo.as_html(selected_images)}
+
+        Here's all the data you've selected.
+
+        {table}
+        """
+    )
+    return clip_outliers_, math, np, plt, selected_images, show_images
+
+
+@app.cell
+async def __():
+    import sys
+
+    if "pyodide" in sys.modules:
+        import micropip
+
+        await micropip.install("altair")
+
+    import altair as alt
+    return alt, micropip, sys
+
+
+@app.cell
+def __():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def __():
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
No rush for this PR. I just wanted to have the procedure documented.

- update polars, add altair
- Add a script that combines metadata + data csv, compresses it as parquet and saves it on /shared/datastore/attribution
- Add 

A couple of things that maybe should be in a separate issue:
- found some duplicated images
- PC1 and 2 are almost fully correlated. We may want to increase the PCs that we plot and add a toggle.

Here a screenshot of how it looks:
![image](https://github.com/user-attachments/assets/12a7cc4c-1366-4906-80c4-bb739f050760)
