### PR TITLE
fix(embed_viz): use correct column

### DIFF
--- a/workspace/analysis/2024_11_30_marimo_explorer.py
+++ b/workspace/analysis/2024_11_30_marimo_explorer.py
@@ -129,9 +129,9 @@ def __(channel, chart, clip_outliers, load_image, mo, table):
         return fig
 
     selected_images = (
-        show_images(list(chart.value["site"]))
+        show_images(list(chart.value["img_id"]))
         if not len(table.value)
-        else show_images(list(table.value["site"]))
+        else show_images(list(table.value["img_id"]))
     )
 
     mo.md(


### PR DESCRIPTION
Turns out I used the wrong key before. Now it seems to work fine.
![image](https://github.com/user-attachments/assets/cbafeaee-904e-4abd-9ba6-72a0269b4287)
